### PR TITLE
Use re2 for regex

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -37,6 +37,9 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
+    - name: Install RE2
+      run: sudo apt-get update && sudo apt-get install -y libre2-dev
+
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:

--- a/.github/workflows/windows-mingw-build.yml
+++ b/.github/workflows/windows-mingw-build.yml
@@ -34,10 +34,16 @@ jobs:
           arch: 'win64_mingw'
           tools: 'tools_mingw1310'
 
+      - name: Install RE2 on Windows
+        id: install-re2-mingw
+        run: vcpkg install re2:x64-mingw-static
+
       - name: CMake Configure
         run: >
           cmake -B ${{ steps.strings.outputs.build-dir }}
           -G "MinGW Makefiles"
+          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          -DVCPKG_TARGET_TRIPLET=x64-mingw-static
           -DCMAKE_BUILD_TYPE=${{ steps.strings.outputs.build-type }}
           -S ${{ github.workspace }}
 

--- a/.github/workflows/windows-msvc-build.yml
+++ b/.github/workflows/windows-msvc-build.yml
@@ -30,11 +30,17 @@ jobs:
           target: 'desktop'
           arch: 'win64_msvc2022_64'
 
+      - name: Install RE2 on Windows
+        run: vcpkg install re2:x64-windows-static-md
+        id: install-re2-windows
+
       - name: CMake Configure
         run: >
           cmake -B ${{ steps.strings.outputs.build-dir }}
           -DCMAKE_CXX_COMPILER=cl
           -DCMAKE_C_COMPILER=cl
+          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          -DVCPKG_TARGET_TRIPLET=x64-windows-static-md
           -DCMAKE_BUILD_TYPE=${{ steps.strings.outputs.build-type }}
           -S ${{ github.workspace }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,17 @@ find_package(Threads REQUIRED)
 
 include(InstallRequiredSystemLibraries)
 
+if(WIN32)
+    # vcpkg provides re2::re2 (CONFIG mode)
+    find_package(re2 CONFIG REQUIRED)
+    set(RE2_TARGET re2::re2)
+else()
+    # Linux uses pkg-config (libre2-dev)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(RE2 REQUIRED IMPORTED_TARGET re2)
+    set(RE2_TARGET PkgConfig::RE2)
+endif()
+
 set(MAIN_SOURCES
     qlogexplorer.qrc
     src/main.cpp
@@ -45,6 +56,13 @@ set(MAIN_SOURCES
     src/Settings.cpp
     src/InFileStream.h
     src/InFileStream.cpp
+    src/regex/Regex.h
+    src/regex/QtRegex.h
+    src/regex/QtRegex.cpp
+    src/regex/Re2Regex.h
+    src/regex/Re2Regex.cpp
+    src/regex/RegexBuilder.h
+    src/regex/RegexBuilder.cpp
 )
 
 if(WIN32)
@@ -141,6 +159,7 @@ target_link_libraries(${PROJECT_NAME}
     Qt${QT_VERSION_MAJOR}::Network
     QtSolutions::SingleApplication
     Threads::Threads
+    ${RE2_TARGET}
 )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR MINGW)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ __Minimum requirements__
 * C++ 17
 * CMake 3.10
 * Qt 6.4
+* RE2
 
 If not using Qt creator, make sure the Qt dir is in the PATH.  
 To build the project via command line:

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -78,6 +78,30 @@ QString elideLeft(const std::string &str, tp::UInt maxSize)
     return res;
 }
 
+bool startsWith(std::string_view str, std::string_view prefix)
+{
+    return (str.size() >= prefix.size()) && (str.compare(0, prefix.size(), prefix) == 0);
+}
+
+bool endsWith(std::string_view str, std::string_view suffix)
+{
+    if (str.length() >= suffix.length())
+    {
+        return (0 == str.compare(str.length() - suffix.length(), suffix.length(), suffix));
+    }
+    return false;
+}
+
+void replaceAll(std::string &data, const std::string &toSearch, const std::string &replaceWith)
+{
+    size_t pos = data.find(toSearch);
+    while (pos != std::string::npos)
+    {
+        data.replace(pos, toSearch.length(), replaceWith);
+        pos = data.find(toSearch, pos + replaceWith.length());
+    }
+}
+
 QVariant toVariant(const tp::Column &column, const QString &text)
 {
     switch (column.type)

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -30,6 +30,11 @@ std::string toStr(const QString &str);
 
 std::string toStr(const QColor &color);
 
+inline QString toQStr(std::string_view str)
+{
+    return QString::fromUtf8(str.data(), str.size());
+}
+
 std::string join(const std::vector<std::string> &strList, const std::string &delim);
 
 std::vector<std::string> split(const std::string &str, const std::string &delim);
@@ -37,6 +42,12 @@ std::vector<std::string> split(const std::string &str, const std::string &delim)
 std::string toUpper(const std::string &text);
 
 QString elideLeft(const std::string &str, tp::UInt maxSize);
+
+bool startsWith(std::string_view str, std::string_view prefix);
+
+bool endsWith(std::string_view str, std::string_view suffix);
+
+void replaceAll(std::string &data, const std::string &toSearch, const std::string &replaceWith);
 
 QVariant toVariant(const tp::Column &column, const QString &text);
 

--- a/src/gui/HeaderView.cpp
+++ b/src/gui/HeaderView.cpp
@@ -33,7 +33,7 @@ QVariant priv::HeaderModel::headerData(int section, Qt::Orientation orientation,
     switch (role)
     {
         case Qt::DisplayRole:
-            return QString::fromStdString(m_columns.at(section).get().name);
+            return utl::toQStr(m_columns.at(section).get().name);
         case Qt::TextAlignmentRole:
             return Qt::AlignLeft;
         case Qt::FontRole:

--- a/src/gui/LogViewWidget.cpp
+++ b/src/gui/LogViewWidget.cpp
@@ -748,7 +748,7 @@ void LogViewWidget::getVisualRowData(tp::SInt row, tp::SInt rowOffset, tp::SInt 
             const tp::SInt colWidth = getTextWidth(colText) + Style::getColumnMargin();
             rect.setWidth(colWidth);
             rect.setLeft(rect.left() + Style::getTextPadding());
-            vcData.can.text = QString::fromStdString(colText);
+            vcData.can.text = utl::toQStr(colText);
             vcData.can.rect = rect;
             if (selectText.has_value() && rect.contains(selectText.value()))
             {
@@ -818,7 +818,7 @@ tp::SInt LogViewWidget::getRowByScreenPos(int yPos) const
 
 tp::SInt LogViewWidget::getTextWidth(const std::string &text, bool simplified)
 {
-    const QString qStr(QString::fromStdString(text));
+    const QString qStr(utl::toQStr(text));
     return Style::getTextWidth(simplified ? qStr.simplified() : qStr);
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -429,6 +429,7 @@ void MainWindow::openAbout()
                     <li><a href="https://www.qt.io">Qt</a></li>
                     <li><a href="https://github.com/fmtlib/fmt">fmt</a></li>
                     <li><a href="https://rapidjson.org">RapidJSON</a></li>
+                    <li><a href="https://github.com/google/re2">RE2</a></li>
                 </ul>
             </p>
         )__").arg(tr("Credits")));

--- a/src/gui/TemplatesConfigDlg.cpp
+++ b/src/gui/TemplatesConfigDlg.cpp
@@ -377,25 +377,28 @@ void TemplatesConfigDlg::createColumnsFromRegex()
             return;
     }
 
-    QRegularExpression rx(m_edtRegex->text());
-    if (!rx.isValid())
+    auto rx = RegexBuilder::build(m_edtRegex->text().toStdString());
+    if (rx->hasError())
     {
-        QMessageBox::critical(this, tr("Error"), tr("The regular expression is not valid.\n%1").arg(rx.errorString()));
+        QMessageBox::critical(
+            this,
+            tr("Error"),
+            tr("The regular expression is not valid.\n%1").arg(utl::toQStr(rx->getError())));
         return;
     }
 
     conf->fillFkColumnKeys();
     conf->clearColumns();
 
-    const auto groupsCount = rx.captureCount();
-    const auto namedGroups = rx.namedCaptureGroups();
+    const auto groupsCount = rx->getCaptureCount();
+    const auto namedGroups = rx->getNamedCaptureGroups();
     for (auto g = 1; g <= groupsCount; ++g)
     {
         tp::Column cl(g - 1);
 
         if (g < namedGroups.size())
         {
-            cl.name = namedGroups.at(g).toStdString();
+            cl.name = namedGroups.at(g);
         }
 
         if (cl.name.empty())

--- a/src/match/RangeMatcher.cpp
+++ b/src/match/RangeMatcher.cpp
@@ -52,8 +52,7 @@ bool RangeMatcher::match(std::string_view text)
     if (!res)
         return false;
 
-    QString qStr = QString::fromUtf8(text.data(), text.size());
-    const auto val(utl::toVariant(m_param.column.value(), qStr));
+    const auto val(utl::toVariant(m_param.column.value(), utl::toQStr(text)));
     if (val.isValid() && !val.isNull())
     {
         if (validFrom)

--- a/src/match/RegexMatcher.cpp
+++ b/src/match/RegexMatcher.cpp
@@ -3,42 +3,69 @@
 
 #include "pch.h"
 #include "RegexMatcher.h"
+#include <QMessageBox>
 
-RegexMatcher::RegexMatcher(const tp::SearchParam &param) : BaseMatcher(param), m_rx(param.pattern.c_str(), getOpts())
+RegexMatcher::RegexMatcher(const tp::SearchParam &param) : BaseMatcher(param)
 {
-    // When parsing raw text the anchors need to be removed, because it runs on full block(many rows at one) and full
+    if (param.pattern.empty())
+        return;
+
+    const auto &pattern = param.pattern;
+    const auto opts = getOpts();
+    m_rx = RegexBuilder::build(pattern, opts);
+    if (m_rx->hasError())
+    {
+        QMessageBox::critical(
+            nullptr,
+            QObject::tr("Error"),
+            QObject::tr("The regular expression is not valid:\n%1").arg(utl::toQStr(m_rx->getError())));
+        m_rx.reset();
+        return;
+    }
+
+    // When parsing raw text the anchors need to be removed, because it runs on full block(many rows) and full
     // row(text is not split into columns)
-    const bool hasAnchor = !param.pattern.empty() && ((param.pattern.front() == '^') || (param.pattern.back() == '$'));
+    const bool hasAnchor = ((pattern.front() == '^') || ((pattern.back() == '$') && !utl::endsWith(pattern, "\\$")));
     if (hasAnchor)
     {
-        QString rawPattern(param.pattern.c_str());
-        if (rawPattern.startsWith('^'))
-            rawPattern.remove(0, 1);
-        if (rawPattern.endsWith('$') && !rawPattern.endsWith("\\$"))
-            rawPattern.chop(1);
-        m_rawRx = QRegularExpression(rawPattern, getOpts());
+        std::string_view rawPattern(pattern);
+        if (rawPattern.front() == '^')
+            rawPattern.remove_prefix(1);
+        if (rawPattern.back() == '$')
+            rawPattern.remove_suffix(1);
+        m_rawRx = RegexBuilder::build(rawPattern, opts);
+        if (m_rawRx->hasError())
+        {
+            LOG_ERR("Invalid raw regex: {}", m_rawRx->getError());
+            m_rawRx.reset();
+        }
     }
 }
 
-QRegularExpression::PatternOptions RegexMatcher::getOpts()
+RegexFlags RegexMatcher::getOpts()
 {
-    QRegularExpression::PatternOptions opts = QRegularExpression::DontCaptureOption;
-    if (!matchCase())
+    RegexFlags opts = RegexOption::DontCapture;
+    if (matchCase())
     {
-        opts |= QRegularExpression::CaseInsensitiveOption;
+        opts.set(RegexOption::CaseSensitive);
     }
     return opts;
 }
 
 bool RegexMatcher::match(std::string_view text)
 {
-    return m_rx.match(QString::fromUtf8(text.data(), text.size())).hasMatch();
+    if (m_rx)
+        return m_rx->hasMatch(text);
+    else
+        return false;
 }
 
 bool RegexMatcher::quickRawMatch(tp::FileType fileType, bool isBlock, std::string_view rawText)
 {
-    if (m_rawRx.has_value())
-        return m_rawRx->match(QString::fromUtf8(rawText.data(), rawText.size())).hasMatch();
+    if (m_rawRx)
+        return m_rawRx->hasMatch(rawText);
+    else if (m_rx)
+        return m_rx->hasMatch(rawText);
     else
-        return match(rawText);
+        return false;
 }

--- a/src/match/RegexMatcher.h
+++ b/src/match/RegexMatcher.h
@@ -9,11 +9,11 @@ class RegexMatcher : public BaseMatcher
 {
 public:
     RegexMatcher(const tp::SearchParam &param);
-    QRegularExpression::PatternOptions getOpts();
+    RegexFlags getOpts();
     bool match(std::string_view text) override;
     bool quickRawMatch(tp::FileType fileType, bool isBlock, std::string_view rawText) override;
 
 private:
-    const QRegularExpression m_rx;
-    std::optional<QRegularExpression> m_rawRx;
+    Regex::Uptr m_rx;
+    Regex::Uptr m_rawRx;
 };

--- a/src/model/BaseLogModel.cpp
+++ b/src/model/BaseLogModel.cpp
@@ -165,6 +165,7 @@ void BaseLogModel::search()
         }
 
         searchingProgressChanged(100);
+        searchTime += timer.elapsed();
 
         if (!rowsPtr->empty())
         {

--- a/src/model/TextLogModel.cpp
+++ b/src/model/TextLogModel.cpp
@@ -23,19 +23,15 @@ bool TextLogModel::configure(FileConf::Ptr conf, std::istream &is)
         {
             conf->addColumn(tp::Column(0));
         }
-        m_rx.setPattern(QString());
+        m_rx.reset();
     }
     else
     {
-        m_rx.setPattern(conf->getRegexPattern().c_str());
-        if (!m_rx.isValid())
+        m_rx = RegexBuilder::build(conf->getRegexPattern());
+        if (m_rx->hasError())
         {
-            LOG_ERR("Invalid regex pattern: '{}': {}", conf->getRegexPattern(), utl::toStr(m_rx.errorString()));
-            m_rx.setPattern(QString());
-        }
-        else
-        {
-            m_rx.optimize();
+            LOG_ERR("Invalid regex pattern: '{}': {}", conf->getRegexPattern(), m_rx->getError());
+            m_rx.reset();
         }
     }
 
@@ -49,15 +45,14 @@ bool TextLogModel::parseRow(std::string_view rawText, tp::RowData &rowData) cons
     if (rawText.back() == '\r')
         rawText.remove_suffix(1);
 
-    if (m_rx.pattern().isEmpty())
+    if (!m_rx)
     {
         rowData.emplace_back(rawText);
     }
     else
     {
-        QUtf8StringView utf8View(rawText.data(), rawText.size());
-        QRegularExpressionMatch match = m_rx.match(QString::fromUtf8(utf8View));
-        if (match.hasMatch())
+        auto match = m_rx->match(rawText);
+        if (match->hasMatch())
         {
             std::string value;
 
@@ -69,11 +64,11 @@ bool TextLogModel::parseRow(std::string_view rawText, tp::RowData &rowData) cons
                     {
                         if (QChar::isDigit(col.key.front()))
                         {
-                            value = match.captured(std::stoi(col.key)).toStdString();
+                            value = match->getCaptured(std::stoi(col.key));
                         }
                         else
                         {
-                            value = match.captured(col.key.c_str()).toStdString();
+                            value = match->getCaptured(col.key.c_str());
                         }
                     }
                     else

--- a/src/model/TextLogModel.h
+++ b/src/model/TextLogModel.h
@@ -25,6 +25,6 @@ protected:
     virtual void loadChunkRows(ChunkRows &chunkRows) const override;
 
 private:
-    QRegularExpression m_rx;
+    Regex::Uptr m_rx;
     tp::FileType m_fileType;
 };

--- a/src/pch.h
+++ b/src/pch.h
@@ -45,3 +45,4 @@
 #include "Types.h"
 #include "Utils.h"
 #include "FileConf.h"
+#include "regex/RegexBuilder.h"

--- a/src/regex/QtRegex.cpp
+++ b/src/regex/QtRegex.cpp
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 Rafael Fassi Lobao
+// This file is part of qlogexplorer project licensed under GPL-3.0
+
+#include "QtRegex.h"
+
+class QtRegexResult : public RegexResult
+{
+public:
+    QtRegexResult(QRegularExpressionMatch &&macher) : m_macher(std::move(macher)) {}
+
+    bool hasMatch() const override { return m_macher.hasMatch(); }
+
+    std::string getCaptured(int groupNumb) const override { return m_macher.captured(groupNumb).toStdString(); }
+
+    std::string getCaptured(std::string_view groupName) const override
+    {
+        return m_macher.captured(utl::toQStr(groupName)).toStdString();
+    }
+
+    QRegularExpressionMatch m_macher;
+};
+
+QtRegex::QtRegex(std::string_view text, RegexFlags opts)
+{
+    build(text, opts);
+}
+
+bool QtRegex::build(std::string_view text, RegexFlags opts)
+{
+    QRegularExpression::PatternOptions options = QRegularExpression::NoPatternOption;
+    if (!opts.has(RegexOption::CaseSensitive))
+    {
+        options |= QRegularExpression::CaseInsensitiveOption;
+    }
+    if (opts.has(RegexOption::DontCapture))
+    {
+        options |= QRegularExpression::DontCaptureOption;
+    }
+
+    m_rx.setPatternOptions(options);
+    m_rx.setPattern(utl::toQStr(text));
+    if (m_rx.isValid())
+    {
+        m_rx.optimize();
+        return true;
+    }
+    return false;
+}
+
+bool QtRegex::hasError()
+{
+    return !m_rx.isValid();
+}
+
+std::string QtRegex::getError() const
+{
+    return m_rx.errorString().toStdString();
+}
+
+bool QtRegex::hasMatch(std::string_view text)
+{
+    return m_rx.match(utl::toQStr(text)).hasMatch();
+}
+
+RegexResult::Uptr QtRegex::match(std::string_view text)
+{
+    return std::make_unique<QtRegexResult>(m_rx.match(utl::toQStr(text)));
+}
+
+int QtRegex::getCaptureCount() const
+{
+    return m_rx.captureCount();
+}
+
+std::vector<std::string> QtRegex::getNamedCaptureGroups()
+{
+    std::vector<std::string> res;
+    const auto groups = m_rx.namedCaptureGroups();
+    res.reserve(groups.size());
+    for (const auto &group : groups)
+    {
+        res.push_back(group.toStdString());
+    }
+    return res;
+}

--- a/src/regex/QtRegex.h
+++ b/src/regex/QtRegex.h
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Rafael Fassi Lobao
+// This file is part of qlogexplorer project licensed under GPL-3.0
+
+#pragma once
+
+#include "regex/Regex.h"
+#include <QRegularExpression>
+
+class QtRegex : public Regex
+{
+public:
+    QtRegex(std::string_view text, RegexFlags opts);
+    bool build(std::string_view text, RegexFlags opts) override;
+    bool hasError() override;
+    std::string getError() const override;
+    bool hasMatch(std::string_view text) override;
+    RegexResult::Uptr match(std::string_view text) override;
+    int getCaptureCount() const override;
+    std::vector<std::string> getNamedCaptureGroups() override;
+
+private:
+    QRegularExpression m_rx;
+};

--- a/src/regex/Re2Regex.cpp
+++ b/src/regex/Re2Regex.cpp
@@ -1,0 +1,153 @@
+// Copyright (C) 2026 Rafael Fassi Lobao
+// This file is part of qlogexplorer project licensed under GPL-3.0
+
+#include "Re2Regex.h"
+
+class Re2RegexResult : public RegexResult
+{
+public:
+    Re2RegexResult() {}
+
+    Re2RegexResult(std::shared_ptr<re2::RE2> rx, std::string_view text) : m_rx(std::move(rx))
+    {
+        if (!m_rx)
+            return;
+
+        m_groups = m_rx->NumberOfCapturingGroups();
+        m_submatches.resize(m_groups + 1); // +1 for the full match
+        m_args.resize(m_groups);
+        m_arg_ptrs.resize(m_groups);
+
+        for (int i = 0; i < m_groups; ++i)
+        {
+            m_args[i] = &m_submatches[i + 1];
+            m_arg_ptrs[i] = &m_args[i];
+        }
+
+        if (re2::RE2::PartialMatchN(text, *m_rx, m_arg_ptrs.data(), m_groups))
+        {
+            m_hasMatch = true;
+        }
+    }
+
+    bool hasMatch() const override { return m_hasMatch; }
+
+    std::string getCaptured(int groupNumb) const override
+    {
+        if (groupNumb < m_submatches.size())
+        {
+            return std::string(m_submatches[groupNumb]);
+        }
+        LOG_ERR("Invalid groupNumb {} size is {}", groupNumb, m_submatches.size());
+        return {};
+    }
+
+    std::string getCaptured(std::string_view groupName) const override
+    {
+        const auto &names = m_rx->NamedCapturingGroups();
+        if (const auto it = names.find(std::string(groupName)); it != names.end())
+        {
+            return getCaptured(it->second);
+        }
+        return {};
+    }
+
+    bool m_hasMatch = false;
+    int m_groups = 0;
+    std::shared_ptr<re2::RE2> m_rx;
+    std::vector<re2::StringPiece> m_submatches; // +1 for the full match
+    std::vector<re2::RE2::Arg> m_args;
+    std::vector<re2::RE2::Arg *> m_arg_ptrs;
+};
+
+Re2Regex::Re2Regex(std::string_view pattern, RegexFlags opts)
+{
+    build(pattern, opts);
+}
+
+bool Re2Regex::build(std::string_view pattern, RegexFlags opts)
+{
+    re2::RE2::Options options;
+    options.set_log_errors(false);
+    options.set_case_sensitive(opts.has(RegexOption::CaseSensitive));
+    options.set_never_capture(opts.has(RegexOption::DontCapture));
+
+    m_rx = std::make_shared<re2::RE2>(pattern, options);
+    if (!m_rx->ok() && (pattern.find("(?<") != std::string_view::npos))
+    {
+        // Versions of RE2 pre-dating 2023-09-01 release only support Python-style
+        // syntax for named groups: "(?P<GroupName>)"
+        LOG_WAR("Trying to fix named group to fix error: {}", m_rx->error());
+        std::string fixedPattern(pattern);
+        utl::replaceAll(fixedPattern, "(?<", "(?P<");
+        m_rx = std::make_shared<re2::RE2>(fixedPattern, options);
+    }
+    return m_rx->ok();
+}
+
+bool Re2Regex::hasError()
+{
+    if (m_rx)
+    {
+        return !m_rx->ok();
+    }
+    return true;
+}
+
+std::string Re2Regex::getError() const
+{
+    if (m_rx)
+    {
+        return m_rx->error();
+    }
+    return "re2 not created";
+}
+
+bool Re2Regex::hasMatch(std::string_view text)
+{
+    if (m_rx)
+    {
+        return re2::RE2::PartialMatch(text, *m_rx);
+    }
+
+    LOG_ERR("hasMatch called without re2 instance");
+    return false;
+}
+
+RegexResult::Uptr Re2Regex::match(std::string_view text)
+{
+    if (m_rx)
+    {
+        return std::make_unique<Re2RegexResult>(m_rx, text);
+    }
+
+    LOG_ERR("match called without re2 instance");
+    return std::make_unique<Re2RegexResult>();
+}
+
+int Re2Regex::getCaptureCount() const
+{
+    if (m_rx)
+    {
+        return m_rx->NumberOfCapturingGroups();
+    }
+    return -1;
+}
+
+std::vector<std::string> Re2Regex::getNamedCaptureGroups()
+{
+    std::vector<std::string> res;
+    if (!m_rx)
+    {
+        return res;
+    }
+
+    const auto &names = m_rx->CapturingGroupNames();
+    res.reserve(names.size() + 1);
+    res.emplace_back(); // full match group
+    for (const auto &[idx, name] : names)
+    {
+        res.emplace_back(name);
+    }
+    return res;
+}

--- a/src/regex/Re2Regex.h
+++ b/src/regex/Re2Regex.h
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Rafael Fassi Lobao
+// This file is part of qlogexplorer project licensed under GPL-3.0
+
+#pragma once
+
+#include "regex/Regex.h"
+#include "re2/re2.h"
+
+class Re2Regex : public Regex
+{
+public:
+    Re2Regex(std::string_view text, RegexFlags opts);
+    bool build(std::string_view text, RegexFlags opts) override;
+    bool hasError() override;
+    std::string getError() const override;
+    bool hasMatch(std::string_view text) override;
+    RegexResult::Uptr match(std::string_view text) override;
+    int getCaptureCount() const override;
+    std::vector<std::string> getNamedCaptureGroups() override;
+
+private:
+    std::shared_ptr<re2::RE2> m_rx;
+};

--- a/src/regex/Regex.h
+++ b/src/regex/Regex.h
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Rafael Fassi Lobao
+// This file is part of qlogexplorer project licensed under GPL-3.0
+
+#pragma once
+
+class RegexResult
+{
+public:
+    using Uptr = std::unique_ptr<RegexResult>;
+
+    virtual bool hasMatch() const = 0;
+    virtual std::string getCaptured(int groupNumb) const = 0;
+    virtual std::string getCaptured(std::string_view groupName) const = 0;
+};
+
+enum class RegexOption
+{
+    CaseSensitive,
+    DontCapture
+};
+using RegexFlags = tp::Flags<RegexOption>;
+
+class Regex
+{
+public:
+    using Uptr = std::unique_ptr<Regex>;
+
+    virtual bool build(std::string_view text, RegexFlags opts) = 0;
+    virtual bool hasError() = 0;
+    virtual std::string getError() const = 0;
+    virtual bool hasMatch(std::string_view text) = 0;
+    virtual RegexResult::Uptr match(std::string_view text) = 0;
+    virtual int getCaptureCount() const = 0;
+    virtual std::vector<std::string> getNamedCaptureGroups() = 0;
+};

--- a/src/regex/RegexBuilder.cpp
+++ b/src/regex/RegexBuilder.cpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Rafael Fassi Lobao
+// This file is part of qlogexplorer project licensed under GPL-3.0
+
+#include "RegexBuilder.h"
+#include "QtRegex.h"
+#include "Re2Regex.h"
+
+Regex::Uptr RegexBuilder::build(std::string_view pattern, RegexFlags opts)
+{
+    if (auto rx = std::make_unique<Re2Regex>(pattern, opts); !rx->hasError())
+    {
+        return rx;
+    }
+    else
+    {
+        LOG_WAR("Re2Regex error {} - falling back to QtRegex", rx->getError());
+        return std::make_unique<QtRegex>(pattern, opts);
+    }
+}

--- a/src/regex/RegexBuilder.h
+++ b/src/regex/RegexBuilder.h
@@ -1,0 +1,12 @@
+// Copyright (C) 2026 Rafael Fassi Lobao
+// This file is part of qlogexplorer project licensed under GPL-3.0
+
+#pragma once
+
+#include "Regex.h"
+
+class RegexBuilder
+{
+public:
+    static Regex::Uptr build(std::string_view pattern, RegexFlags opts = {});
+};


### PR DESCRIPTION
- Use re2 to speed up regex search.
- If the pattern is not supported by re2 falls back to QRegularExpression.